### PR TITLE
Add Erayo's Essence as edge case for BaseLegalityChecker

### DIFF
--- a/PDBot.Core/GameObservers/BaseLegalityChecker.cs
+++ b/PDBot.Core/GameObservers/BaseLegalityChecker.cs
@@ -96,6 +96,9 @@ namespace PDBot.Core.GameObservers
                 }
             }
 
+            if (name == "Erayo, Soratami Ascendant's Essence")
+                name = "Erayo's Essence";
+
             if (Transforms.Contains(name))
                 return true;
 

--- a/Tests/TestTransforms.cs
+++ b/Tests/TestTransforms.cs
@@ -37,6 +37,7 @@ namespace Tests
         public void TestFlip()
         {
             Assert.IsTrue(BaseLegalityChecker.IsRearFace("Erayo's Essence"));
+            Assert.IsTrue(BaseLegalityChecker.IsRearFace("Erayo, Soratami Ascendant's Essence"));
         }
 
         [Test]


### PR DESCRIPTION
Fixes bot not recognizing Erayo's Essence as legal, caused by MTGO having the wrong card name for flipped Erayo, Soratami Ascendant.

The card "Erayo, Soratami Ascendant" should be named "Erayo's Essence" when flipped, but MTGO has this card wrongly named "Erayo, Soratami Ascendant's Essence". 

The card on scryfall:
https://scryfall.com/card/sok/35/erayo-soratami-ascendant-erayos-essence?utm_source=api

How the card looks on MTGO:
![image](https://user-images.githubusercontent.com/23155456/152359899-340d0b98-b50a-4e4c-bd19-6825d8381b8f.png)

This change just switches the wrong name to the correct one, so when we ask the Scryfall api it returns correct information.