### PR TITLE
Legitimate businessperson from witness protection added as special case

### DIFF
--- a/PDBot.Core/Data/GameLogLine.cs
+++ b/PDBot.Core/Data/GameLogLine.cs
@@ -20,6 +20,7 @@ namespace PDBot.Core.Data
             "Marit Lage", "Kaldra", "Ragavan", "Ashaya, the Awoken World", "Stangg Twin",
             "Voja", "Urami", "Tuktuk the Returned", "Servo", "Nightmare Horror",
             "Voja, Friend to Elves", "Vitu-Ghazi", "Etherium Cell", "Wizard",
+			"Legitimate Businessperson",
         };
 
         public string Line { get; private set; }

--- a/Tests/TestLogs.cs
+++ b/Tests/TestLogs.cs
@@ -16,6 +16,7 @@ namespace Tests
         [TestCase("[Elvish Visionary] blocks [Tuktuk the Returned].", 1, 1)]
         [TestCase("Blockers for [Vampire Nighthawk] are ordered as follows: [Glint-Nest Crane], [Faerie Mechanist]", 3, 0)]
         [TestCase("jmblinn13 is being attacked by [Spirit Token].", 0, 1)]
+        [TestCase("Tygrak is being attacked by [Legitimate Businessperson].", 0, 1)]
         public void TestLogHandler(string line, int cards, int tokens)
         {
             var match = new MockMatch();
@@ -49,7 +50,7 @@ namespace Tests
             Assert.IsTrue(legality.IsCardLegal(CardName.FixAccents("DandAþn")));
             Assert.IsFalse(legality.IsCardLegal(CardName.FixAccents("Lim-dl")));
         }
-
+        
         [Test]
         public void TestSparkSpitter()
         {


### PR DESCRIPTION
Added Legitimate Businessperson to GameLogLine.cs LegendaryTokens, to fix https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/10084. Also added a test for this case to TestLogs.

![witnessProtection](https://user-images.githubusercontent.com/23155456/167287091-7aff8e20-a126-4eab-9bba-8b96e8e01870.PNG)
