### PR TITLE
Added the changed name of The Irencrag to LegendaryTokens (Everflame, Heroes' Legacy)

### DIFF
--- a/PDBot.Core/Data/GameLogLine.cs
+++ b/PDBot.Core/Data/GameLogLine.cs
@@ -20,7 +20,7 @@ namespace PDBot.Core.Data
             "Marit Lage", "Kaldra", "Ragavan", "Ashaya, the Awoken World", "Stangg Twin",
             "Voja", "Urami", "Tuktuk the Returned", "Servo", "Nightmare Horror",
             "Voja, Friend to Elves", "Vitu-Ghazi", "Etherium Cell", "Wizard",
-            "Legitimate Businessperson", "Walker",
+            "Legitimate Businessperson", "Walker", "Everflame, Heroes' Legacy"
         };
 
         public string Line { get; private set; }

--- a/Tests/TestLogs.cs
+++ b/Tests/TestLogs.cs
@@ -17,6 +17,7 @@ namespace Tests
         [TestCase("Blockers for [Vampire Nighthawk] are ordered as follows: [Glint-Nest Crane], [Faerie Mechanist]", 3, 0)]
         [TestCase("jmblinn13 is being attacked by [Spirit Token].", 0, 1)]
         [TestCase("Tygrak is being attacked by [Legitimate Businessperson].", 0, 1)]
+        [TestCase("Username activates an ability of [Everflame, Heroes' Legacy] targeting [Tameshi, Reality Architect].", 1, 1)]
         public void TestLogHandler(string line, int cards, int tokens)
         {
             var match = new MockMatch();


### PR DESCRIPTION
Added a new card to LegendaryTokens and a testcase for it in TestLogs.cs

Just a new addition from wotc of a card that can have a different name without being a token. The bot previously said it isn't legal.

![woe-248-the-irencrag](https://github.com/PennyDreadfulMTG/PDBot/assets/23155456/c471a5e8-25a2-445a-b48e-4833681777a1)

first reported here: https://discord.com/channels/207281932214599682/230056266938974218/1184135156425044050