### PR TITLE
fix error 400 when doing web requests

### DIFF
--- a/PDBot.Core/GameObservers/BaseLegalityChecker.cs
+++ b/PDBot.Core/GameObservers/BaseLegalityChecker.cs
@@ -108,9 +108,11 @@ namespace PDBot.Core.GameObservers
             if (NotTransforms.Contains(name))
                 return false;
 
-            var url = $"https://api.scryfall.com/cards/named?exact={name}";
+            var escapedCardName = Uri.EscapeDataString(name);
+            var url = $"https://api.scryfall.com/cards/named?exact={escapedCardName}";
             using var wc = new WebClient();
             wc.Headers[HttpRequestHeader.UserAgent] = "PDBot";
+            wc.Headers[HttpRequestHeader.Accept] = "application/json";
             try
             {
                 var blob = wc.DownloadString(url);


### PR DESCRIPTION
When debugging and running tests locally I noticed that I always run into error 400 when sending web requests in `Scryfall.cs` and in `BaseLegalityChecker`. This fails the tests, and if this happens in the live version I believe it will cause bugs.