### PR TITLE
Fix/cards with accents

### DIFF
--- a/PDBot.Core/API/Scryfall.cs
+++ b/PDBot.Core/API/Scryfall.cs
@@ -48,7 +48,9 @@ namespace PDBot.Core.API
                 return Cache[name];
             }
 
-            var address = $"/cards/search?q={name}+lang:en&include_multilingual=true";
+            var query = $"{name} lang:en";
+            var encodedQuery = Uri.EscapeDataString(query);
+            var address = $"/cards/search?q={encodedQuery}&include_multilingual=true";
             var cards = HitMultiCardAPI(address).ToArray();
             var card = cards.FirstOrDefault(c => c.Names.Contains(name));
             return card;

--- a/PDBot.Core/API/Scryfall.cs
+++ b/PDBot.Core/API/Scryfall.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace PDBot.Core.API
 {
@@ -80,7 +79,7 @@ namespace PDBot.Core.API
                         BaseAddress = "https://api.scryfall.com/",
                         Encoding = Encoding.UTF8,
                     };
-                    wc.Headers[HttpRequestHeader.UserAgent] = "PDBot";
+                    SetUpHeaders(wc);
                     var blob = wc.DownloadString("catalog/card-names");
                     var json = Newtonsoft.Json.JsonConvert.DeserializeObject(blob) as JObject;
                     CardNames = json["data"].Values<string>().ToArray<string>();
@@ -105,9 +104,8 @@ namespace PDBot.Core.API
                 using var wc = new WebClient
                 {
                     BaseAddress = "https://api.scryfall.com/",
-
                 };
-                wc.Headers[HttpRequestHeader.UserAgent] = "PDBot";
+                SetUpHeaders(wc);
                 var blob = wc.DownloadString(address);
                 var json = Newtonsoft.Json.JsonConvert.DeserializeObject(blob) as JObject;
                 return ParseJson(json);
@@ -150,12 +148,13 @@ namespace PDBot.Core.API
             string blob;
             try
             {
-
                 using var wc = new WebClient
                 {
                     BaseAddress = "https://api.scryfall.com/"
                 };
-                wc.Headers[HttpRequestHeader.UserAgent] = "PDBot";
+
+                SetUpHeaders(wc);
+                
                 Console.WriteLine(address);
                 blob = wc.DownloadString(address);
             }
@@ -190,6 +189,12 @@ namespace PDBot.Core.API
                 else
                     yield break;
             }
+        }
+
+        static void SetUpHeaders(WebClient wc)
+        {
+            wc.Headers[HttpRequestHeader.UserAgent] = "PDBot";
+            wc.Headers[HttpRequestHeader.Accept] = "application/json";
         }
     }
 }

--- a/PDBot.Core/Data/CardName.cs
+++ b/PDBot.Core/Data/CardName.cs
@@ -28,17 +28,7 @@ namespace PDBot.Data
             }
             catch (WebException) { }
         }
-
-        /// <summary>
-        /// Takes a name, and fixes up any messy encoding issues that might have occured.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public static string FixAccents(string name)
-        {
-            return Encoding.UTF8.GetString(Encoding.GetEncoding("iso-8859-1").GetBytes(name));
-        }
-
+        
         public static string NormalizeString(string name)
         {
             var normalizedString = name.Normalize(NormalizationForm.FormKD);
@@ -74,8 +64,6 @@ namespace PDBot.Data
             FullName = FullName.Trim('\r');
             if (FullName.StartsWith("\""))
                 FullName = FullName.Trim('\"');
-            if (!RealCards.Contains(FullName))
-                FullName = FixAccents(FullName);
             if (Regex.IsMatch(FullName, @"(\w+)/(\w+)"))
                 FullName = FullName.Replace("/", " // ");
             this.FullName = FullName;

--- a/PDBot.Core/Data/GameLogLine.cs
+++ b/PDBot.Core/Data/GameLogLine.cs
@@ -60,7 +60,6 @@ namespace PDBot.Core.Data
                     return;
                 }
                 var name = line.Substring(1, end - 1);
-                name = CardName.FixAccents(name);
                 line = line.Substring(end + 1);
                 var IsToken = line.TrimStart().StartsWith("token", StringComparison.InvariantCultureIgnoreCase);
                 if (name.EndsWith("Token", StringComparison.InvariantCultureIgnoreCase))

--- a/PDBot.Core/GameObservers/BaseLegalityChecker.cs
+++ b/PDBot.Core/GameObservers/BaseLegalityChecker.cs
@@ -73,6 +73,7 @@ namespace PDBot.Core.GameObservers
             if (LegalCards == null)
             {
                 using var webClient = new WebClient();
+                webClient.Encoding = Encoding.UTF8;
                 LegalCards = webClient.DownloadString(LegalListUrl).Split('\n');
                 LegalCards = LegalCards.Select(n => new CardName(n)).SelectMany(cn => cn.Names).ToArray();
             }

--- a/Tests/TestLogs.cs
+++ b/Tests/TestLogs.cs
@@ -40,30 +40,6 @@ namespace Tests
             ClassicAssert.IsNotNull(checker.HandleLine(new GameLogLine("[Black Lotus] is never going to be 0.01 TIX.", match)));
             ClassicAssert.IsNull(checker.HandleLine(new GameLogLine("[Black Lotus] is never going to be 0.01 TIX.", match)));
         }
-
-        [Test]
-        public void TestAccents()
-        {
-            ClassicAssert.AreEqual("Dandân", new CardName("Dandân").FullName);
-            ClassicAssert.AreEqual("Junún Efreet", new CardName("Junún Efreet"));
-            ClassicAssert.AreEqual("Márton Stromgald", new CardName("Márton Stromgald").FullName);
-            ClassicAssert.AreEqual("Dandân", new CardName("DandÃ¢n").FullName);
-            ClassicAssert.AreEqual("Lim-Dûl the Necromancer", new CardName("Lim-DÃ»l the Necromancer").FullName);
-            ClassicAssert.AreEqual("Barad-dûr", new CardName("Barad-dÃ»r").FullName);
-            ClassicAssert.AreEqual("Ifh-Bíff Efreet", new CardName("Ifh-BÃ­ff Efreet").FullName);
-        }
-
-        [Test]
-        public void TestLegalCardsForAccents()
-        {
-            var legality = new PennyDreadfulLegality();
-            Assume.That(legality.IsCardLegal("Island"));
-            foreach (var name in legality.LegalCards)
-            {
-                var n = CardName.FixAccents(name);
-                ClassicAssert.IsFalse(n.Contains("Ã"), $"{name} contains an Ã.");
-            }
-        }
         
         [Test]
         public void TestSparkSpitter()


### PR DESCRIPTION
**NOTE:** This PR is rebased from [this PR](https://github.com/PennyDreadfulMTG/PDBot/pull/238) so take a look at that one first if you haven't already.

This PR fixes two issues:

- The `FixAccents` method was corrupting strings and making the `TestAccents` tests fail. I have removed the method.
- We had missing UTF8 encoding in `IsCardLegal` when fetching the legal cards from the .txt tile. This might be what the above `FixAccents` method was trying to fix before, but with the encoding it's no longer needed.

The above should fix most issues with cards names with accents. One potential issue that remains is specifically accented capital E's `("É")`. MTGO itself seems to not be able to parse this one so I am unsure how the string that PDBot gets from the game log actually looks. If you know please let me know and I can include a fix for this as well. 