### PR TITLE
Fix prepared cards

### DIFF
--- a/PDBot.Core/Data/GameLogLine.cs
+++ b/PDBot.Core/Data/GameLogLine.cs
@@ -13,6 +13,8 @@ namespace PDBot.Core.Data
     {
         static Regex NewToken = new Regex(@"creates (a|an|two) (?<name>[\w\s]+).", RegexOptions.Compiled);
         static Regex Transreliquat = new Regex(@"targeting \[(?<name>[\w\s]+)\] token \(.* becomes a copy of target", RegexOptions.Compiled);
+        static Regex NewPrepared = new Regex(@"prepares (?<name>[\w\s',\-]+)$", RegexOptions.Compiled);
+        
         /// <summary>
         /// A list of tokens that are too good for the word "token"
         /// </summary>
@@ -33,19 +35,27 @@ namespace PDBot.Core.Data
             if (createsMatch.Success)
             {
                 var name = createsMatch.Groups["name"].Value;
-                if (!name.EndsWith("token", StringComparison.InvariantCultureIgnoreCase) && !LegendaryTokens.Contains(name) && !match.NamedTokens.Contains(name))
+                if (!name.EndsWith("token", StringComparison.InvariantCultureIgnoreCase) && !LegendaryTokens.Contains(name) && !match.NamedTokensAndPreparedSpells.Contains(name))
                 {
-                    match.NamedTokens.Add(name);
+                    match.NamedTokensAndPreparedSpells.Add(name);
                 }
             }
             var copiesToken = Transreliquat.Match(line);
             if (copiesToken.Success)
             {
                 var name = copiesToken.Groups["name"].Value;
-                if (!LegendaryTokens.Contains(name) && !match.NamedTokens.Contains(name))
+                if (!LegendaryTokens.Contains(name) && !match.NamedTokensAndPreparedSpells.Contains(name))
                 {
-                    match.NamedTokens.Add(name);
+                    match.NamedTokensAndPreparedSpells.Add(name);
                 }
+            }
+            
+            var preparedMatch = NewPrepared.Match(line);
+            if (preparedMatch.Success)
+            {
+                var name = preparedMatch.Groups["name"].Value;
+                if (!match.NamedTokensAndPreparedSpells.Contains(name))
+                    match.NamedTokensAndPreparedSpells.Add(name);
             }
 
             this.Line = line;
@@ -65,7 +75,7 @@ namespace PDBot.Core.Data
                 var IsToken = line.TrimStart().StartsWith("token", StringComparison.InvariantCultureIgnoreCase);
                 if (name.EndsWith("Token", StringComparison.InvariantCultureIgnoreCase))
                     IsToken = true;
-                if (LegendaryTokens.Contains(name) || match.NamedTokens.Contains(name))
+                if (LegendaryTokens.Contains(name) || match.NamedTokensAndPreparedSpells.Contains(name))
                     IsToken = true;
 
                 if (IsToken)
@@ -76,9 +86,9 @@ namespace PDBot.Core.Data
                 {
                     this.Cards.Add(name);
                 }
-                if (name == "Garth One-Eye" && !match.NamedTokens.Contains("Disenchant"))
+                if (name == "Garth One-Eye" && !match.NamedTokensAndPreparedSpells.Contains("Disenchant"))
                 {
-                    match.NamedTokens.AddRange(new string[] { "Disenchant", "Braingeyser", "Terror", "Shivan Dragon", "Regrowth", "Black Lotus" });
+                    match.NamedTokensAndPreparedSpells.AddRange(new string[] { "Disenchant", "Braingeyser", "Terror", "Shivan Dragon", "Regrowth", "Black Lotus" });
                 }
             }
         }

--- a/PDBot.Core/Interfaces/IMatch.cs
+++ b/PDBot.Core/Interfaces/IMatch.cs
@@ -22,6 +22,6 @@ namespace PDBot.Core.Interfaces
         void SendChat(string message);
         string Log(string message);
 
-        List<string> NamedTokens { get; }
+        List<string> NamedTokensAndPreparedSpells { get; }
     }
 }

--- a/Tests/Mocks/MockMatch.cs
+++ b/Tests/Mocks/MockMatch.cs
@@ -53,7 +53,7 @@ namespace Tests.Mocks
 
         public MagicFormat Format { get; }
 
-        public List<string> NamedTokens { get; } = new List<string>();
+        public List<string> NamedTokensAndPreparedSpells { get; } = new List<string>();
 
         public int MatchID => 1;
 

--- a/Tests/TestLogs.cs
+++ b/Tests/TestLogs.cs
@@ -76,5 +76,23 @@ namespace Tests
             CountCards("WookieeGT's [Sparkspitter] creates a Spark Elemental.", 1, 0, match);
             CountCards("TheFancyMusterd is being attacked by [Spark Elemental] and [Fusion Elemental].", 1, 1, match);
         }
+
+        [Test]
+        public void TestPreparedSpells()
+        {
+            // Given empty whitelist
+            var match = new MockMatch();
+            ClassicAssert.IsEmpty(match.NamedTokensAndPreparedSpells);
+            
+            // When some creatures become prepared with some spells
+            var logLine = new GameLogLine("[Studious First-Year] prepares Rampant Growth", match);
+            var logline2 = new GameLogLine("[Vastlands Scavenger] prepares Bind to Life", match);
+
+            // Then the spells should be whitelisted
+            ClassicAssert.True(match.NamedTokensAndPreparedSpells.Contains("Rampant Growth"));
+            ClassicAssert.True(match.NamedTokensAndPreparedSpells.Contains("Bind to Life"));
+            CountCards("frzpop casts [Rampant Growth].", cards:0, tokens:1, match);
+            CountCards("frzpop casts [Bind to Life].", cards:0, tokens:1, match);
+        }
     }
 }


### PR DESCRIPTION
Handles loglines where a creature prepares a spell and adds that spell to the tokens whitelist. Includes a test that covers the change.